### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/focus-cli/security/code-scanning/3](https://github.com/legnoh/focus-cli/security/code-scanning/3)

To fix the problem, add a `permissions` block to the `build` job (at the same indentation level as `runs-on`, before `steps`). Set it to the minimal required privileges. Since the `build` job only checks out code and runs a build, it only needs `contents: read` to fetch the repository code. No parts of the job require additional permissions, so this is the least privilege change that also aligns with the CodeQL recommendation. The only code change required is inserting the `permissions: contents: read` lines after `runs-on: ubuntu-latest` within the `build` job in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
